### PR TITLE
Cleanup some commented code in `ini.pp`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,16 +29,8 @@ class bootstrap ($print_console_login = false) {
     ],
     require => Package['yum-plugin-priorities'],
   }
-  #  yumrepo { [ 'updates', 'base', 'extras']:
-  #  enabled  => '0',
-  #  priority => '99',
-  #  skip_if_unavailable => '1',
-  #}
-  ## Include epel but leave it disabled.
-  #class { 'epel':
-  #  epel_enabled => '0',
-  #  before => Class['localrepo'],
-  #}
+
+  # ensure the EPEL repo is present
   include epel
 
   # Moving the root user declaration to the userprefs module.


### PR DESCRIPTION
This commit cleans up some commented code from the `init.pp` file. This
code was commented as it is no longer needed, but since this is version
control, we need not comment it to preserve it.