### PR TITLE
(maint) Remove udev persistent net naming

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,6 +129,13 @@ class bootstrap ($print_console_login = false) {
     force   => true,
   }
 
+  # Remove the udev ethernet naming rules, causes problems when
+  # moving VMs around. This works for rhel/centos
+  file {'/etc/udev/rules.d/70-persistent-net.rules':
+    ensure   => absent,
+    force    => true,
+  }
+
   # Disable GSS-API for SSH to speed up log in
   $ruby_aug_package = $::osfamily ? {
     'RedHat' => 'ruby-augeas',


### PR DESCRIPTION
By default on rhel/centos, detected ethernet interfaces are added to the
/etc/udev/rules.d/70-persistent-net.rules file to ensure consistent
device addressing. This breaks with VMs, where devices and addressing
needs to be fluid as they move around.

This removes the file so that no static device naming will be enforced.
Previously, we were doing this in the kickstart file, but now that we are
using vmpooler VMs, we need to remove it in the configuration stage.