### PR TITLE
Cache 32bit agent

### DIFF
--- a/manifests/get_32bit_agent.pp
+++ b/manifests/get_32bit_agent.pp
@@ -10,7 +10,7 @@ class bootstrap::get_32bit_agent(
   $puppet_dir   = '/opt/puppet'
   $repo_dir     = "${puppet_dir}/packages"
   $public_dir   = "${repo_dir}/public"
-  $version_dir  = "${public_dir}/${verision}"
+  $version_dir  = "${public_dir}/${version}"
   $agent_dir    = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-i386-agent"
   $agent_file   = "${agent_dir}.tar.gz"
   $url          = "https://s3.amazonaws.com/pe-builds/released/${version}"

--- a/manifests/get_32bit_agent.pp
+++ b/manifests/get_32bit_agent.pp
@@ -3,7 +3,7 @@
 # -------
 
 class bootstrap::get_32bit_agent(
-  $version   = 'latest',
+  $version        = '3.7.2',
   $architecture   = $::architecture,
   $file_cache     = '/vagrant/file_cache'
 ) {

--- a/manifests/get_32bit_agent.pp
+++ b/manifests/get_32bit_agent.pp
@@ -1,0 +1,27 @@
+# -------
+# Fetch PE and unzip full installer
+# Stage agent installer.
+# -------
+
+class bootstrap::get_32bit_agent(
+  $version   = 'latest',
+  $pe_destination = '/root',
+  $architecture   = $::architecture,
+  $file_cache     = '/vagrant/file_cache'
+) {
+  $pe_dir        = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-i386"
+  $agent_file     = "${pe_dir}-agent.tar.gz"
+  $url            = "https://s3.amazonaws.com/pe-builds/released/${version}"
+
+  # Check if there is a locally cached copy from the build
+  if file_exists ("${file_cache}/installers/${agent_file}") == 1 {
+    staging::file{ $agent_file:
+      source => "${file_cache}/installers/${agent_file}",
+    }
+  }
+  else {
+    staging::file{ $agent_file:
+      source => "${url}/${agent_file}",
+    }
+  }
+}

--- a/manifests/get_32bit_agent.pp
+++ b/manifests/get_32bit_agent.pp
@@ -1,27 +1,37 @@
 # -------
-# Fetch PE and unzip full installer
-# Stage agent installer.
+# Fetch and unzip 32bit agent installer
 # -------
 
 class bootstrap::get_32bit_agent(
   $version   = 'latest',
-  $pe_destination = '/root',
+  $repo_dir = '/opt/puppet/packages/',
   $architecture   = $::architecture,
   $file_cache     = '/vagrant/file_cache'
 ) {
-  $pe_dir        = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-i386"
-  $agent_file     = "${pe_dir}-agent.tar.gz"
+  $agent_dir        = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-i386-agent"
+  $agent_file     = "${agent_dir}.tar.gz"
+  $public_dir     = "${repo_dir}/public"
   $url            = "https://s3.amazonaws.com/pe-builds/released/${version}"
 
-  # Check if there is a locally cached copy from the build
-  if file_exists ("${file_cache}/installers/${agent_file}") == 1 {
-    staging::file{ $agent_file:
-      source => "${file_cache}/installers/${agent_file}",
-    }
+  file { $repo_dir:
+    ensure => directory,
   }
-  else {
-    staging::file{ $agent_file:
-      source => "${url}/${agent_file}",
-    }
+  file { "${public_dir}/":
+    ensure => directory,
+  }
+  file { "${public_dir}/${version}":
+    ensure => directory,
+  }
+  staging::deploy { $agent_file:
+    source  => "${url}/${agent_file}",
+    target  => "${public_dir}/",
+    creates => "${public_dir}/${agent_dir}",
+    require => File["${public_dir}/"]
+  }
+  #our nice symlink to make the .repo files happy
+  file { "${public_dir}/${version}/el-${operatingsystemmajrelease}-i386":
+    ensure  => link,
+    target  => "${public_dir}/${agent_dir}/agent_packages/${installer_build}",
+    require => [Staging::Deploy[$agent_file],File["${public_dir}/${version}"]],
   }
 }

--- a/manifests/get_32bit_agent.pp
+++ b/manifests/get_32bit_agent.pp
@@ -4,34 +4,30 @@
 
 class bootstrap::get_32bit_agent(
   $version   = 'latest',
-  $repo_dir = '/opt/puppet/packages/',
+  $puppet_dir = '/opt/puppet',
   $architecture   = $::architecture,
   $file_cache     = '/vagrant/file_cache'
 ) {
+  $repo_dir       = "${puppet_dir}/packages"
+  $public_dir     = "${repo_dir}/public"
+  $version_dir     = "${public_dir}/${verision}"
   $agent_dir        = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-i386-agent"
   $agent_file     = "${agent_dir}.tar.gz"
-  $public_dir     = "${repo_dir}/public"
   $url            = "https://s3.amazonaws.com/pe-builds/released/${version}"
 
-  file { $repo_dir:
-    ensure => directory,
-  }
-  file { "${public_dir}/":
-    ensure => directory,
-  }
-  file { "${public_dir}/${version}":
-    ensure => directory,
+  file { [$puppet_dir,$repo_dir,$public_dir,$version_dir]:
+    ensure => directory
   }
   staging::deploy { $agent_file:
     source  => "${url}/${agent_file}",
-    target  => "${public_dir}/",
+    target  => $public_dir,
     creates => "${public_dir}/${agent_dir}",
-    require => File["${public_dir}/"]
+    require => File[$public_dir]
   }
   #our nice symlink to make the .repo files happy
-  file { "${public_dir}/${version}/el-${operatingsystemmajrelease}-i386":
+  file { "${version_dir}/el-${operatingsystemmajrelease}-i386":
     ensure  => link,
     target  => "${public_dir}/${agent_dir}/agent_packages/${installer_build}",
-    require => [Staging::Deploy[$agent_file],File["${public_dir}/${version}"]],
+    require => [Staging::Deploy[$agent_file],File[$version_dir]],
   }
 }

--- a/manifests/get_32bit_agent.pp
+++ b/manifests/get_32bit_agent.pp
@@ -4,16 +4,16 @@
 
 class bootstrap::get_32bit_agent(
   $version   = 'latest',
-  $puppet_dir = '/opt/puppet',
   $architecture   = $::architecture,
   $file_cache     = '/vagrant/file_cache'
 ) {
-  $repo_dir       = "${puppet_dir}/packages"
-  $public_dir     = "${repo_dir}/public"
-  $version_dir     = "${public_dir}/${verision}"
-  $agent_dir        = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-i386-agent"
-  $agent_file     = "${agent_dir}.tar.gz"
-  $url            = "https://s3.amazonaws.com/pe-builds/released/${version}"
+  $puppet_dir   = '/opt/puppet'
+  $repo_dir     = "${puppet_dir}/packages"
+  $public_dir   = "${repo_dir}/public"
+  $version_dir  = "${public_dir}/${verision}"
+  $agent_dir    = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-i386-agent"
+  $agent_file   = "${agent_dir}.tar.gz"
+  $url          = "https://s3.amazonaws.com/pe-builds/released/${version}"
 
   file { [$puppet_dir,$repo_dir,$public_dir,$version_dir]:
     ensure => directory


### PR DESCRIPTION
Downloads and unzips the 32bit agent installer.
Allows classifying with 32bit pe-repo class while offline.