### PR TITLE
Refactored agent installer caching

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,9 +18,10 @@
   "project_page": "https://github.com/puppetlabs/pltraining-bootstrap",
   "issues_url": "https://github.com/puppetlabs/pltraining-bootstrap/issues",
   "description": "Bootstrap scripts for Puppetlabs Education VMs",
-  "dependencies": [  
+  "dependencies": [
     {"name":"stahnma/epel"},
     {"name":"pltraining/userprefs"},
-    {"name":"puppetlabs/pe_gem"}
+    {"name":"puppetlabs/pe_gem"},
+    {"name":"pltraining/dirtree"}
   ]
 }


### PR DESCRIPTION
Instead of duplicating logic and work from the `pe_repo` class, just
short-circuit the tarball download, and let `pe_repo` finish the work.

This is tested on and offline with 2015.2.0 + el-6.

Note: I verified the logic in `pe_repo`. It will only fall through to
the failure clause if it gets a valid http error code indicating that
the repository doesn't contain a tarball. In the case of no-network, it
will still attempt the download so that `staging` can raise its own
error message.