### PR TITLE
Refactor classes to use params

### DIFF
--- a/manifests/profile/get_pe.pp
+++ b/manifests/profile/get_pe.pp
@@ -2,15 +2,14 @@
 # Fetch PE and unzip full installer
 # -------
 
-class bootstrap::profile::get_pe(
-  $version   = '2015.2.0',
+class bootstrap::profile::get_pe (
+  $version        = $bootstrap::params::pe_version,
   $pe_destination = '/root',
   $architecture   = $::architecture,
   $file_cache     = '/vagrant/file_cache'
-) {
-  $pe_dir        = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-${architecture}"
+) inherits bootstrap::params {
+  $pe_dir         = "puppet-enterprise-${version}-el-${operatingsystemmajrelease}-${architecture}"
   $pe_file        = "${pe_dir}.tar.gz"
-  $agent_file     = "puppet-agent-el-6-i386.tar.gz"
   $url            = "https://s3.amazonaws.com/pe-builds/released/${version}"
 
   Staging::File {

--- a/manifests/profile/installer_staging.pp
+++ b/manifests/profile/installer_staging.pp
@@ -1,6 +1,8 @@
 class bootstrap::profile::installer_staging {
+  include bootstrap::params
+
   class { 'staging':
-    path   => '/usr/src/installer/',
+    path   => $bootstrap::params::source_path,
     owner  => 'root',
     group  => 'root',
   }


### PR DESCRIPTION
Lowers maintenance burden, we'll only have to update variables once.
This depends on the `params` class introduced in #35