### PR TITLE
Cache AWS demo gems

### DIFF
--- a/manifests/profile/cache_gems.pp
+++ b/manifests/profile/cache_gems.pp
@@ -98,6 +98,10 @@ class bootstrap::profile::cache_gems (
   bootstrap::gem { 'systemu':                        version => '2.5.2'  }
 
 
+  # for the Architect AWS demo
+  bootstrap::gem { 'aws-sdk-core':}
+  bootstrap::gem { 'retries':}
+
   Bootstrap::Gem <| |> -> File['/root/.gemrc']
 
 }


### PR DESCRIPTION
At some point, can either @carthik or @js verify a version range to pin
these gems to?

TRAINVM-233 #resolved