### PR TITLE
Don't rely on facter to show IP address

### DIFF
--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -6,7 +6,8 @@
 
 touch /var/lock/subsys/local
 
-IP_ADDRESS=$(RUBYLIB="/usr/src/facter/lib" /usr/src/facter/bin/facter ipaddress)
+PRIMARY_INTERFACE=$(netstat -nr | tail -n+3 | head -1 | awk '{print $8}')
+IP_ADDRESS=$(ifconfig $PRIMARY_INTERFACE | grep inet | head -1 | awk '{print $2}')
 
 echo \
 "                --- Welcome to the PuppetLabs <%= @hostname.capitalize -%> VM ---

--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -7,7 +7,7 @@
 touch /var/lock/subsys/local
 
 PRIMARY_INTERFACE=$(netstat -nr | tail -n+3 | head -1 | awk '{print $8}')
-IP_ADDRESS=$(ifconfig $PRIMARY_INTERFACE | grep inet | head -1 | awk '{print $2}')
+IP_ADDRESS=$(ifconfig $PRIMARY_INTERFACE | grep inet | head -1 | awk '{print $2}' | sed 's/addr://')
 
 echo \
 "                --- Welcome to the PuppetLabs <%= @hostname.capitalize -%> VM ---


### PR DESCRIPTION
As terrible as this is, it's actually more robust than previous versions.

First, we grab the name of the network adapter that's attached to the default gateway.  Then we grab the address of that interface from ifconfig.