### PR TITLE
Remove floppy driver

### DIFF
--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -49,4 +49,7 @@ Your password was randomly generated from the text of the GNU public license
 It is stored in /var/local/password and will continue to appear on this screen
 " > /etc/issue
 
+# Disable the floppy driver
+rmmod floppy
+
 /root/.ssh_keygen.sh &


### PR DESCRIPTION
LEARNVM-281 #resolved #time 6h

Blacklisting the driver didn't work, the floppy is disabled in the VM, for some reason the driver still gets loaded.  This manually removes it.