### PR TITLE
TRAINVM-252 #resolved #time 30m

### DIFF
--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -20,7 +20,7 @@ then
   # Generate wordlist from GPL
   for word in $(cat $GPL_PATH/GPL)
   do
-    echo $word | grep '[a-zA-Z]' >> /tmp/wordlist
+    echo $word | grep '^[a-zA-Z]*$' >> /tmp/wordlist
   done
 
   # Generate password in format WORD.Number.WORD


### PR DESCRIPTION
This was matching anything with a-zA-Z in the line.  The new regex only matches strings where all the chars are alpha.