### PR TITLE
Install stunnel remove unneeded dependency

### DIFF
--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -22,9 +22,8 @@ class bootstrap::profile::base {
   }
 
   # Add a few extra packages for convenience
-  package { [ 'patch', 'screen', 'telnet', 'tree' ] :
+  package { [ 'patch', 'screen', 'telnet', 'tree', 'stunnel' ] :
     ensure  => present,
-    require => Class['localrepo'],
   }
 
   # /etc/puppet/ssl is confusing to have around. Sloppy. Kill.


### PR DESCRIPTION
The dependency on localrepo is no longer required.