### PR TITLE
Cache docker images on master

### DIFF
--- a/manifests/profile/cache_docker.pp
+++ b/manifests/profile/cache_docker.pp
@@ -1,0 +1,8 @@
+class bootstrap::profile::cache_docker {
+
+  include docker
+  docker::image { 'maci0/systemd':}
+  docker::image { 'phusion/baseimage':}
+
+}
+

--- a/manifests/role/master.pp
+++ b/manifests/role/master.pp
@@ -9,4 +9,5 @@ class bootstrap::role::master {
   include bootstrap::profile::pe_tweaks
   include bootstrap::profile::disable_selinux
   include bootstrap::public_key
+  include bootstrap::profile::cache_docker
 }

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,7 @@
     {"name":"puppetlabs/pe_gem"},
     {"name":"pltraining/dirtree"},
     {"name":"jfryman/selinux"},
-    {"name":"binford2k/abalone"}
+    {"name":"binford2k/abalone"},
+    {"name":"garethr/docker"}
   ]
 }


### PR DESCRIPTION
Preinstalls docker and caches the two images we use in class.  This increases the VM size by ~300mb, but will drastically improve classification time for most courses.