### PR TITLE
Run abalone on a different port

### DIFF
--- a/manifests/role/training.pp
+++ b/manifests/role/training.pp
@@ -11,5 +11,7 @@ class bootstrap::role::training (
     ec2_lock_passwd => false,
   }
   include bootstrap::profile::disable_selinux 
-  include abalone
+  class { 'abalone':
+    port => '9091'
+  }
 }


### PR DESCRIPTION
Port 9090 conflicts with the proxy lab in architect.