### PR TITLE
Preseed classroom module on first boot

### DIFF
--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -58,4 +58,19 @@ To set a new password, run the command: reset_password.rb
 # Disable the floppy driver
 rmmod floppy
 
+<% unless @hostname == "learning" %>
+if ! [ -d "/etc/puppetlabs/code/modules/classroom" ]
+then
+  # set up the puppet codebase
+  puppet module install pltraining/classroom --modulepath /etc/puppetlabs/code-staging/modules
+  cp -a /etc/puppetlabs/code-staging/modules/* /etc/puppetlabs/code/modules/
+  chown -R pe-puppet:pe-puppet /etc/puppetlabs/code/modules
+
+  # set up deploy user
+  puppet plugin download
+  puppet resource rbac_user deployer ensure=present display_name=deployer email=deployer@puppetlabs.vm password=puppetlabs roles=4
+  echo 'puppetlabs' | puppet access login deployer --lifetime 5d
+fi
+<% end %>
+
 /root/.ssh_keygen.sh &


### PR DESCRIPTION
This will put all the required modules in both code-staging and in
codedir, with the proper permissions set. This means that it is useful
with and without code manager turned on.

It will also generate the deployer user and configure an access token.

This is not my favorite approach, but this is a finnicky tool to setup
and I cannot find a better way.

COURSES-2217 #time 12h