### PR TITLE
This adds a script to help resolve module dependencies

### DIFF
--- a/files/scripts/classroom/dependency_nuke.rb
+++ b/files/scripts/classroom/dependency_nuke.rb
@@ -1,0 +1,24 @@
+#! /usr/bin/env ruby
+require 'fileutils'
+
+def usage()
+  puts "This script will just force remove all dependencies of a module."
+  puts "This will let you install it fresh and let it pull the dependencies it needs."
+  puts
+  puts "    dependency_nuke.rb puppetlabs/windows [--modulepath /etc/puppetlabs/code-staging/modules]"
+end
+
+usage() unless [1,3].include? ARGV.size
+
+mod = ARGV.shift
+IO.popen("puppet module install #{mod} --modulepath /tmp/nuker --debug").readlines.each do |line|
+  next unless line =~ /Debug: HTTP GET.*module=(\w*-\w*)/
+
+  puts "Uninstalling #{$1}..."
+  system("puppet module uninstall #{$1} #{ARGV.join(' ')} > /dev/null 2>&1")
+end
+
+FileUtils.rm_rf '/tmp/nuker'
+puts
+puts "Now try installing #{mod} again and see if dependencies are properly resolved."
+puts "- You may need to reinstall modules that were removed."

--- a/files/scripts/classroom/dependency_nuke.rb
+++ b/files/scripts/classroom/dependency_nuke.rb
@@ -15,7 +15,7 @@ IO.popen("puppet module install #{mod} --modulepath /tmp/nuker --debug").readlin
   next unless line =~ /Debug: HTTP GET.*module=(\w*-\w*)/
 
   puts "Uninstalling #{$1}..."
-  system("puppet module uninstall #{$1} #{ARGV.join(' ')} > /dev/null 2>&1")
+  system("puppet module uninstall #{$1} #{ARGV.join(' ')} --force > /dev/null 2>&1")
 end
 
 FileUtils.rm_rf '/tmp/nuker'


### PR DESCRIPTION
This will just force remove all dependencies of a module. This means
that when you try to install it again, it will only use the dependencies
described in that module, rather than trying to reconcile it with the
currently installed module versions.

WARNING: This will **remove** modules from your modulepath.

Note: I'm not entirely certain this is really a good idea. I'd rather
that people were able and willing to debug module dependencies on their
own rather than running this nuke-from-orbit script. My worry is that if
this does resolve their issues that they'll never get around to telling
us so that we can fix it, and that they won't understand that it's
actually removing modules that they might need to reinstall.