### PR TITLE
Increase token lifetime

### DIFF
--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -84,6 +84,6 @@ if ! [ -f "/root/.puppetlabs/token" ]
   # set up deploy user
   puppet plugin download
   puppet resource rbac_user deployer ensure=present display_name=deployer email=deployer@puppetlabs.vm password=puppetlabs roles=4
-  echo 'puppetlabs' | HOME=/root /opt/puppetlabs/bin/puppet-access login deployer --lifetime 5d
+  echo 'puppetlabs' | HOME=/root /opt/puppetlabs/bin/puppet-access login deployer --lifetime 14d
 fi
 <% end %>


### PR DESCRIPTION
If we stand up virtual classes 2 business days before a class and students request a few extra days after class, the 5 day lifetime can easily expire.