### PR TITLE
Support offline module installation

### DIFF
--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -72,6 +72,10 @@ if ! [ -d "/etc/puppetlabs/code/modules/classroom" ]
 then
   # set up the puppet codebase
   puppet module install pltraining/classroom --modulepath /etc/puppetlabs/code-staging/modules
+  if [ $? -ne 0 ]
+  then
+    cp -a /usr/src/forge/* /etc/puppetlabs/code-staging/modules/
+  fi
   cp -a /etc/puppetlabs/code-staging/modules/* /etc/puppetlabs/code/modules/
   chown -R pe-puppet:pe-puppet /etc/puppetlabs/code/modules
 fi


### PR DESCRIPTION
This extends the auto-installation logic to also work when modules cannot be installed from the forge. This will cover offline classes, and when upstream modules break dependency resolution.

The one concern here, is that it's a silent failure. It's likely that we won't get reports of invalid dependencies from the field. That's *probably* ok, since we'll be testing dependency resolution each time the VM is built.