### PR TITLE
Allow the puppet_gem provider to use our cache

### DIFF
--- a/manifests/profile/cache_gems.pp
+++ b/manifests/profile/cache_gems.pp
@@ -44,6 +44,15 @@ class bootstrap::profile::cache_gems (
     source => 'puppet:///modules/bootstrap/gemrc',
   }
 
+  # this is for the vendored gem install.
+  file { '/opt/puppetlabs/puppet/etc':
+    ensure => directory,
+  }
+  file { '/opt/puppetlabs/puppet/etc/gemrc':
+    ensure => file,
+    source => 'puppet:///modules/bootstrap/gemrc',
+  }
+  
   # Please keep this list alphabetized and organized. It makes it much easier to update.
   # Puppet Enterprise
   bootstrap::gem { 'hocon':                          version => '0.9.3'  }


### PR DESCRIPTION
`/opt/puppetlabs/puppet/bin/gem` will not use `/root/.gemrc` or `/etc/gemrc`. This commit allows the vendored gem command to use the cache and work offline.
