### PR TITLE
Create deployer user at build time

### DIFF
--- a/manifests/profile/deployer.pp
+++ b/manifests/profile/deployer.pp
@@ -1,0 +1,11 @@
+class bootstrap::profile::deployer(
+  $password = 'puppetlabs',
+) {
+  rbac_user {'deployer':
+    ensure       => present,
+    display_name => 'deployer',
+    email        => 'deployer@puppetlabs.vm',
+    password     => $password,
+    roles        => '4',
+  }
+}

--- a/manifests/role/master.pp
+++ b/manifests/role/master.pp
@@ -17,4 +17,5 @@ class bootstrap::role::master {
   include bootstrap::profile::pdf_stack
   include bootstrap::profile::rubygems
   include bootstrap::profile::cache_gitea
+  include bootstrap::profile::deployer
 }


### PR DESCRIPTION
This moves the deployer user creation to build time instead of 1st boot. A post build script creates the token, but this PR doesn't alter the rc.local so it's still backwards compatible.