### PR TITLE
Cache the courseware gem

### DIFF
--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -1,7 +1,11 @@
 define bootstrap::gem(
   $cache_dir = '/var/cache/rubygems/gems',
-  $version   = undef
+  $version   = undef,
+  $source    = undef,
 ) {
+  if ($version and $source) {
+    fail("You can specify only one of source/version for bootstrap::gem[${name}]")
+  }
 
   if $version {
     $gem     = "${name} -v ${version}"
@@ -12,8 +16,15 @@ define bootstrap::gem(
     $pattern = "${name}-[0-9]*\\.[0-9]*\\.[0-9]*"
   }
 
+  if $source {
+    $command = "wget ${source}"
+  }
+  else {
+    $command = "gem fetch ${gem}"
+  }
+
   # use unless instead of creates because without a version number, we need a regex
-  exec { "gem fetch ${gem}":
+  exec { $command:
     path    => '/opt/puppet/bin:/usr/local/bin:/usr/bin:/bin',
     cwd     => $cache_dir,
     unless  => "find ${cache_dir} -type f -name '${pattern}.gem' | grep '.*'",

--- a/manifests/profile/cache_gems.pp
+++ b/manifests/profile/cache_gems.pp
@@ -52,7 +52,7 @@ class bootstrap::profile::cache_gems (
     ensure => file,
     source => 'puppet:///modules/bootstrap/gemrc',
   }
-  
+
   # Please keep this list alphabetized and organized. It makes it much easier to update.
   # Puppet Enterprise
   bootstrap::gem { 'hocon':                          version => '0.9.3'  }
@@ -129,8 +129,8 @@ class bootstrap::profile::cache_gems (
   bootstrap::gem { 'bundler':                        version => '1.10.6' }
 
   # Required for the aws module
-  bootstrap::gem { 'aws-sdk':                        version => '2.6.9' }
-  bootstrap::gem { 'aws-sdk-core':                   version => '2.6.9' }
+  bootstrap::gem { 'aws-sdk':                        version => '2.6.9'  }
+  bootstrap::gem { 'aws-sdk-core':                   version => '2.6.9'  }
   bootstrap::gem { 'jmespath':                       version => '1.3.1'  }
   bootstrap::gem { 'retries':                        version => '0.0.5'  }
 
@@ -143,6 +143,14 @@ class bootstrap::profile::cache_gems (
   bootstrap::gem { 'table_print':}
 
   # used by classroom scripts
+
+  # PDF printing stack
+  bootstrap::gem { 'kramdown':                       version => '1.13.0' }
+  bootstrap::gem { 'mdl':                            version => '0.4.0'  }
+  bootstrap::gem { 'mixlib-cli':                     version => '1.7.0'  }
+  bootstrap::gem { 'mixlib-config':                  version => '2.2.4'  }
+  bootstrap::gem { 'word_wrap':                      version => '1.0.0'  }
+  bootstrap::gem { 'courseware':  source => 'https://s3-us-west-2.amazonaws.com/education-packages/courseware-0.3.1.gem', }
 
   Bootstrap::Gem <| |> -> File['/root/.gemrc']
 


### PR DESCRIPTION
This adds the ability to cache gems by source URLs and caches the
courseware gem. This will rely on us keeping the S3 copy as up-to-date
as we need it to be.

Next sprint after we're certain that all instructors have updated their
VM, convert the classroom pdf stack manifest to use this.

COURSES-2001 #resolved #time 1h