### PR TITLE
Regenerate network script

### DIFF
--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -62,13 +62,16 @@ To set a new password, run the command: reset_password.rb
 " > /etc/issue
 
 # Regenerate network script for legacy CLI commands
-rm /etc/sysconfig/network-scripts/ifcfg-enp*
-echo \
+if [ ! -s /etc/sysconfig/network-scripts/ifcfg-$PRIMARY_INTERFACE ] && [ $PRIMARY_INTERFACE ]
+then
+  rm /etc/sysconfig/network-scripts/ifcfg-enp*
+  echo \
 "
 DEVICE=$PRIMARY_INTERFACE
 BOOTPROTO=dhcp
 ONBOOT=yes
 " > /etc/sysconfig/network-scripts/ifcfg-$PRIMARY_INTERFACE
+fi
 
 # Disable the floppy driver
 rmmod floppy

--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -61,6 +61,15 @@ The password can be found in /var/local/password as well as this screen.
 To set a new password, run the command: reset_password.rb
 " > /etc/issue
 
+# Regenerate network script for legacy CLI commands
+rm /etc/sysconfig/network-scripts/ifcfg-enp*
+echo \
+"
+DEVICE=$PRIMARY_INTERFACE
+BOOTPROTO=dhcp
+ONBOOT=yes
+" > /etc/sysconfig/network-scripts/ifcfg-$PRIMARY_INTERFACE
+
 # Disable the floppy driver
 rmmod floppy
 


### PR DESCRIPTION
VMware and Virtualbox give the interfaces different names, so importing the VM into vmware leaves behind a network script with the incorrect name. These scripts aren't used by the `ip` command and the networks starts without them, so it seems safe to dynamically recreate it at boot.