### PR TITLE
Update courseware gem

### DIFF
--- a/manifests/profile/cache_gems.pp
+++ b/manifests/profile/cache_gems.pp
@@ -152,7 +152,7 @@ class bootstrap::profile::cache_gems (
   bootstrap::gem { 'mixlib-cli':                     version => '1.7.0'  }
   bootstrap::gem { 'mixlib-config':                  version => '2.2.4'  }
   bootstrap::gem { 'word_wrap':                      version => '1.0.0'  }
-  bootstrap::gem { 'puppet-courseware-manager':      version => '0.5.0'  }
+  bootstrap::gem { 'puppet-courseware-manager':      version => '0.5.1'  }
 
   Bootstrap::Gem <| |> -> File['/root/.gemrc']
 


### PR DESCRIPTION
This enables the courseware gem to pull the PDF password from the `showoff.json` rather than asking interactively. This will enable us to use it for PDF generation on the master.