### PR TITLE
Remove unused docker images and preinstall nokogiri

### DIFF
--- a/manifests/profile/cache_docker.pp
+++ b/manifests/profile/cache_docker.pp
@@ -5,6 +5,8 @@ class bootstrap::profile::cache_docker {
   }
   
   # Build the centos docker container so it is cached
-  include puppetfactory::centosimage
+  class { 'puppetfactory::centosimage':
+    master_address => 'master.puppetlabs.vm'
+  }
 }
 

--- a/manifests/profile/cache_docker.pp
+++ b/manifests/profile/cache_docker.pp
@@ -3,9 +3,8 @@ class bootstrap::profile::cache_docker {
   class { 'docker':
     repo_opt => '--setopt=docker.skip_if_unavailable=true'
   }
-  docker::image { 'centos:7':}
-
-  # Build the docker containers so they are cached
-  include puppetfactory::dockerimages
+  
+  # Build the centos docker container so it is cached
+  include puppetfactory::centosimage
 }
 

--- a/manifests/profile/cache_docker.pp
+++ b/manifests/profile/cache_docker.pp
@@ -3,9 +3,7 @@ class bootstrap::profile::cache_docker {
   class { 'docker':
     repo_opt => '--setopt=docker.skip_if_unavailable=true'
   }
-  docker::image { 'maci0/systemd':} # TODO: remove when releasing v5.13
   docker::image { 'centos:7':}
-  docker::image { 'phusion/baseimage':}
 
   # Build the docker containers so they are cached
   include puppetfactory::dockerimages

--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -13,5 +13,9 @@ class bootstrap::profile::rubygems {
     ensure   => present,
     provider => puppet_gem,
   }
+  package { 'nokogiri':
+    ensure   => '1.6.8.1',
+    provider => gem,
+  }
 }
 


### PR DESCRIPTION
Turns out we were caching a bunch of docker images that we don't use anymore. This added a lot to the size of the VM.  This PR goes along with one in Puppetfactory to split the ubuntuagent and centosagent image builds, since only the centosagent is strictly needed for offline classes.