### PR TITLE
Add postgres module to learning vm local_modules

### DIFF
--- a/manifests/profile/learning/local_modules.pp
+++ b/manifests/profile/learning/local_modules.pp
@@ -13,6 +13,8 @@ class bootstrap::profile::learning::local_modules (
     "https://forge.puppet.com/v3/files/dwerder-graphite-5.16.1.tar.gz",
     "https://forge.puppet.com/v3/files/puppetlabs-apache-1.11.0.tar.gz",
     "https://forge.puppet.com/v3/files/puppetlabs-concat-2.2.0.tar.gz",
+    "https://forge.puppet.com/v3/files/puppetlabs-postgresql-4.8.0.tar.gz",
+    "https://forge.puppet.com/v3/files/puppetlabs-apt-2.4.0.tar.gz",
   ]
 
   $learning_modules.each | $module | {


### PR DESCRIPTION
The puppetlabs-postgresql module needs to be cached on the learning
vm for the forge quest and following quests