### PR TITLE
Move the proxy VM to the end of the list so it doesn't interfere with port mappings when Windows VMs are suspended and a global "vagrant up" is issued later.

### DIFF
--- a/templates/classroom_in_a_box/vms.yaml.epp
+++ b/templates/classroom_in_a_box/vms.yaml.epp
@@ -5,11 +5,6 @@ vms:
   usable_port_range: 2200..2299
   roles:
   - pe-puppet-master
-- name: proxy.puppetlabs.vm
-  box: current-puppet-student-ova
-  usable_port_range: 2200..2299
-  roles:
-  - pe-puppet-agent-linux
 <% range(1, $num_win_vms).each |$n| { -%>
 - name: windows<%= $n %>.puppetlabs.vm
   box: opentable/win-2012r2-standard-amd64-nocm
@@ -17,3 +12,8 @@ vms:
   roles:
   - pe-puppet-agent-windows
 <% } -%>
+- name: proxy.puppetlabs.vm
+  box: current-puppet-student-ova
+  usable_port_range: 2200..2299
+  roles:
+  - pe-puppet-agent-linux


### PR DESCRIPTION
TRAINTECH-1163 #resolved #time 1h