### PR TITLE
Get dependencies for yum cache

### DIFF
--- a/manifests/profile/cache_rpms.pp
+++ b/manifests/profile/cache_rpms.pp
@@ -10,7 +10,7 @@ class bootstrap::profile::cache_rpms {
     ensure => present,
   }
   exec {'cache packages':
-    command   => "yumdownloader --resolve --destdir=${repo_dir} ${pkglist}",
+    command   => "yumdownloader --resolve --installroot=/tmp --destdir=${repo_dir} ${pkglist}",
     path      => '/bin',
     logoutput => false,
     require   => Yumrepo['epel'],

--- a/manifests/profile/cache_rpms.pp
+++ b/manifests/profile/cache_rpms.pp
@@ -10,7 +10,7 @@ class bootstrap::profile::cache_rpms {
     ensure => present,
   }
   exec {'cache packages':
-    command   => "yum install --downloadonly --downloaddir=${repo_dir} ${pkglist}",
+    command   => "yumdownloader --resolve --destdir=${repo_dir} ${pkglist}",
     path      => '/bin',
     logoutput => false,
     require   => Yumrepo['epel'],

--- a/manifests/profile/cache_rpms.pp
+++ b/manifests/profile/cache_rpms.pp
@@ -10,8 +10,9 @@ class bootstrap::profile::cache_rpms {
     ensure => present,
   }
   exec {'cache packages':
-    command   => "yumdownloader --resolve --installroot=/tmp --destdir=${repo_dir} ${pkglist}",
+    command   => "repotrack -p ${repo_dir} ${pkglist}",
     path      => '/bin',
+    timeout   => '600',
     logoutput => false,
     require   => Yumrepo['epel'],
   }


### PR DESCRIPTION
Yum was not downloading packages that were already installed. Repotrack makes sure all the dependencies for every package is there.