### PR TITLE
Properly caches custom packages

### DIFF
--- a/manifests/profile/cache_gitea.pp
+++ b/manifests/profile/cache_gitea.pp
@@ -1,3 +1,6 @@
+# DEPRECATED: This class is deprecated and should be removed after two
+#             pltraining-classroom module releases
+#
 # NOTE: The gitea RPM is built from the Vagrant environment in the
 #       pltraining-gitea-build repository. Please see
 #       https://github.com/puppetlabs/pltraining-gitea-build for detailed

--- a/manifests/role/learning.pp
+++ b/manifests/role/learning.pp
@@ -1,7 +1,6 @@
 class bootstrap::role::learning {
   include userprefs::profile
   include bootstrap
-  include bootstrap::profile::cache_rpms
   include bootstrap::profile::rubygems
   include bootstrap::profile::network
   include bootstrap::profile::pe_tweaks
@@ -24,6 +23,9 @@ class bootstrap::role::learning {
   }
   class { 'bootstrap::profile::cache_gems':
     use_stickler => true,
+  }
+  class { 'bootstrap::profile::cache_rpms':
+    build => 'learning',
   }
   class { 'bootstrap::profile::ruby':
     install_bundler => true,

--- a/metadata.json
+++ b/metadata.json
@@ -31,6 +31,7 @@
     {"name":"razorsedge/network"},
     {"name":"puppetlabs/stdlib"},
     {"name":"puppet/virtualbox"},
+    {"name":"puppet/archive"},
     {"name":"unibet/vagrant"}
   ]
 }


### PR DESCRIPTION
This caches gitea and the droid font so that we can install them in the
classroom. ~~We'll need to wait a couple weeks before changing the
classroom module to match.~~ Actually, no. The prior version of the VM
had the RPMs cached in the proper place, so we should be able to just
install them.

This adds a requirement on `puppet/archive` so we can stop reinventing
the wheel.

TRAINTECH-1248 #time 45m