### PR TITLE
Remove obsolete parameter

### DIFF
--- a/manifests/profile/dockeragent.pp
+++ b/manifests/profile/dockeragent.pp
@@ -3,7 +3,6 @@ class bootstrap::profile::dockeragent {
   # We'll probably want to modify this at some point to use published images.
 
   class { 'dockeragent':
-    create_no_agent_image => true,
     lvm_bashrc            => true,
     install_dev_tools     => true,
   }


### PR DESCRIPTION
The dockeragent module now builds the "agent" image using "no_agent" as a base image, so this parameter was removed.