### PR TITLE
Use standard dockeragent image

### DIFF
--- a/manifests/profile/cache_docker.pp
+++ b/manifests/profile/cache_docker.pp
@@ -6,10 +6,17 @@ class bootstrap::profile::cache_docker {
   contain docker
 
   # Build the centos docker container so it is cached
-  dockeragent::image { 'centosagent':
-    install_agent => true,
-    yum_cache => true,
+  file { '/etc/docker/centosagent/':
+    ensure => directory,
+  }
+  file { '/etc/docker/centosagent/Dockerfile':
+    ensure  => file,
+    content => 'FROM agent',
+  }
+  include dockeragent
+  docker::image { 'centosagent':
+    ensure      => present,
+    docker_file => '/etc/docker/centosagent/Dockerfile',
   }
 
 }
-


### PR DESCRIPTION
The dockeragent::image type is not supposed to be used outside of the module which was causing the image to be missing packages. This uses the standard image and adds an identical image called "centosagent" in order to be compatible with puppetfactory.