### PR TITLE
Preserve hostname for EC2 machines

### DIFF
--- a/templates/99_puppetlabs.cfg.epp
+++ b/templates/99_puppetlabs.cfg.epp
@@ -1,4 +1,5 @@
 hostname: <%= $ec2_hostname %>
+preserve_hostname: true
 system_info:
   default_user:
     name: <%= $admin_user %>


### PR DESCRIPTION
According to this: https://aws.amazon.com/premiumsupport/knowledge-center/linux-static-hostname-rhel7-centos7/

we need to set preserve_hostname to true in order to stop EC2 from changing the hostname.