### PR TITLE
Fix hieradata for non-lvm builds

### DIFF
--- a/manifests/profile/pe_tuning.pp
+++ b/manifests/profile/pe_tuning.pp
@@ -12,8 +12,6 @@ class bootstrap::profile::pe_tuning {
 
 # Make sure that Hiera is configured for the master so that we
 # can demo and so we can use hiera for configuration.
-class classroom::master::hiera {
-  assert_private('This class should not be called directly')
 
   File {
     owner => 'root',

--- a/templates/hiera/hiera.master.yaml.epp
+++ b/templates/hiera/hiera.master.yaml.epp
@@ -1,3 +1,4 @@
+<% | String $hieradata | -%>
 ---
 :backends:
   - yaml
@@ -9,5 +10,5 @@
   - global
 
 :yaml:
-  :datadir: /etc/puppetlabs/code/hieradata
+  :datadir: <%= $hieradata %> 
 


### PR DESCRIPTION
There was some copypasta from the classroom module that was breaking this class, but also the template it was trying to use doesn't exist, so that would've caused problems.