### PR TITLE
Install pdf building tools on training VM

### DIFF
--- a/manifests/role/training.pp
+++ b/manifests/role/training.pp
@@ -4,6 +4,7 @@ class bootstrap::role::training inherits bootstrap::params {
   include bootstrap::profile::cache_modules
   include bootstrap::profile::cache_rpms
   include bootstrap::profile::cache_docker
+  include bootstrap::profile::pdf_stack
   include bootstrap::profile::network
   include userprefs::defaults
   include bootstrap::profile::splash


### PR DESCRIPTION
Some instructors like to demo installing PE on the training VM instead of the preinstalled master. This adds showoff support to that VM.