### PR TITLE
Allow alternate starting hostname for master VM

### DIFF
--- a/manifests/profile/pe_tuning.pp
+++ b/manifests/profile/pe_tuning.pp
@@ -12,6 +12,11 @@ class bootstrap::profile::pe_tuning {
     ensure => file,
     source => 'puppet:///modules/bootstrap/defaults.yaml',
   }
+  
+  file { "${hieradata}/master.puppetlabs.vm.yaml":
+    ensure => link,
+    target => "${hieradata}/${fqdn}.yaml",
+   }
 
   # Make sure that Hiera is configured for the master so that we
   # can demo and so we can use hiera for configuration.


### PR DESCRIPTION
This creates a link in hieradata so that there will always be an entry for master.puppetlabs.vm even if the initial FQDN is different because of local DNS or other possible confounders.