### PR TITLE
Pre-install public_suffix 2.0.5

### DIFF
--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -19,7 +19,7 @@ class bootstrap::profile::rubygems {
     provider => gem,
   }
   package { 'public_suffix':
-    ensure => '2.0.5',
+    ensure   => '2.0.5',
     provider => gem,
   }
 }

--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -18,5 +18,8 @@ class bootstrap::profile::rubygems {
     ensure   => '1.6.8.1',
     provider => gem,
   }
+  package { 'public_suffix':
+    ensure => '2.0.5',
+    provider => gem,
+  }
 }
-


### PR DESCRIPTION
This is a work-around to avoid Ruby >= 2.1 requirement of newer versions of public_suffix. The public_suffix gem is a dependency of showoff and abalone.