### PR TITLE
Adjust console resolution so it's readable

### DIFF
--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -51,6 +51,12 @@ class bootstrap::profile::base {
     provider => gem,
   }
 
+  # make the console text usable again. It's way too high resolution for a VM by default.
+  kernel_parameter { 'vga':
+    ensure => present,
+    value  => '832',  # 800x600 @ 32bit
+  }
+
   file {'/etc/puppetlabs-release':
     ensure  => file,
     content => $bootstrap::params::ptb_version,

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,7 @@
   "dependencies": [
     {"name": "binford2k/abalone"      },
     {"name": "garethr/docker"         },
+    {"name": "herculesteam-augeasproviders_grub" },
     {"name": "jfryman/selinux"        },
     {"name": "stahnma/epel"           },
     {"name": "pltraining/userprefs"   },


### PR DESCRIPTION
I'm not fully convinced we should manage this. Perhaps it should be left up to individual instructors? I somehow think that they won't much mind. I think they'd prefer it to be readable (like this) and if they want higher resolution, they'll be SSHing in anyway.