### PR TITLE
Revert "Allow alternate starting hostname for master VM"

### DIFF
--- a/manifests/profile/pe_tuning.pp
+++ b/manifests/profile/pe_tuning.pp
@@ -12,11 +12,6 @@ class bootstrap::profile::pe_tuning {
     ensure => file,
     source => 'puppet:///modules/bootstrap/defaults.yaml',
   }
-  
-  file { "${hieradata}/master.puppetlabs.vm.yaml":
-    ensure => link,
-    target => "${hieradata}/${fqdn}.yaml",
-   }
 
   # Make sure that Hiera is configured for the master so that we
   # can demo and so we can use hiera for configuration.


### PR DESCRIPTION
Reverts puppetlabs/pltraining-bootstrap#291

This fix was for the self-provisioning script, turns out this breaks the VM build.