### PR TITLE
abalone requires rubygems class

### DIFF
--- a/manifests/profile/abalone.pp
+++ b/manifests/profile/abalone.pp
@@ -3,7 +3,6 @@ class bootstrap::profile::abalone {
   class { 'abalone':
     port => '9091',
     bannerfile => '/etc/issue',
-    require => Class['bootstrap::profile::rubygems'],
   }
 
   file_line { 'pam_securetty':

--- a/manifests/profile/abalone.pp
+++ b/manifests/profile/abalone.pp
@@ -3,6 +3,7 @@ class bootstrap::profile::abalone {
   class { 'abalone':
     port => '9091',
     bannerfile => '/etc/issue',
+    require => Class['bootstrap::profile::rubygems'],
   }
 
   file_line { 'pam_securetty':

--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -6,7 +6,7 @@ class bootstrap::profile::rubygems {
   package { ['cmake3', 'cmake', 'gcc', 'zlib', 'zlib-devel']:
     ensure => present,
     require => Class['epel'],
-    before  => Package['puppetdb-ruby', 'colorize', 'puppetclassify', 'nokogiri'],
+    before  => Package['puppetdb-ruby', 'colorize', 'puppetclassify', 'nokogiri', 'public_suffix'],
   }
 
   # these are used for various scripts
@@ -21,5 +21,6 @@ class bootstrap::profile::rubygems {
   package { 'public_suffix':
     ensure   => '2.0.5',
     provider => gem,
+    before   => Package['abalone'],
   }
 }


### PR DESCRIPTION
Abalone must come after rubygems to ensure gem pre-reqs are correctly set up.