### PR TITLE
Add option for additional ssh key

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,4 +2,11 @@ class bootstrap::params {
   $source_path     = '/usr/src/installer/'
   $admin_user      = 'training'
   $ec2_lock_passwd = true
+
+  # training.pem
+  $admin_ssh_key   = 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCv+89n9QU8kPxhsoRAHt5CZMy4cyA7vQ8k60wZmyUHnmFtXH8Ipusj9QyV8GsL/F64ci3bS0eHlk5XlAFACsLy4Gai6CQ2NAjkZRT7qG5BtoGr4aGXhxFCUZ2hgo2j18uU6GKl2akRPsYMsRgNrRglidENLY4WUCzacgr/1Cw8eRN95Mo9b4tgSLTCyd/783CBdeM8qU9Go7xq0nVRGNgsFIqf1SY+9k5dpSbL0M5lvDzl35IC1tRIQE/ZbafJok8g1XmhwKokWpGBRk9/GneWz3jDvJRZPjYHzQs+gSHNkl2F6i55EIlQqbfm/7lvtB73Pd2vT+i1AIgrx90YB4Yd'
+
+  # puppet_classroom.pub in the presentation downloads
+  $additional_key  = 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDT4hxLhcccJhKRHp5uSEpmE3EgXaOlL72qI7T8cJOh/hov/MsCd8IVGc1fE1romqCjS6vITn9L/tPeJOwmGSih0iUWEQd6CY/OZttdnlelwaGke12hPiuqYqEqGcExNrGoynTQWMz99T6cdyd9HptCGdYGK1EwCi3hmv9QBZGChUbnQKqi3Zc1Uubpzp6WyTXaDoxLxlxX7QXt8K7cRaAviDZ/I07svoO9RwZPqGyeeyh4k1pAYTik8jY58rMmDCNcp6jM4AWAF786k77GI/DBzACJ7kt1Qe8fGLlm7UyV/nSZhxiKs3TcfqBypPf+tQzvfvSfRdVvoMQQOw38ogqT'
+
 }

--- a/manifests/profile/abalone.pp
+++ b/manifests/profile/abalone.pp
@@ -1,5 +1,4 @@
 class bootstrap::profile::abalone {
-
   class { 'abalone':
     port => '9091',
     bannerfile => '/etc/issue',
@@ -11,14 +10,4 @@ class bootstrap::profile::abalone {
     line  => '#auth [user_unknown=ignore success=ok ignore default=bad] pam_security.so',
     match => 'pam_securetty.so$',
   }
-
-  # Provide a backup login method. The public half of this key is on the
-  # Downloads page of the Courseware presentation
-  ssh_authorized_key { 'training@puppet.com':
-    ensure => present,
-    user   => 'training',
-    type   => 'ssh-rsa',
-    key    => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDT4hxLhcccJhKRHp5uSEpmE3EgXaOlL72qI7T8cJOh/hov/MsCd8IVGc1fE1romqCjS6vITn9L/tPeJOwmGSih0iUWEQd6CY/OZttdnlelwaGke12hPiuqYqEqGcExNrGoynTQWMz99T6cdyd9HptCGdYGK1EwCi3hmv9QBZGChUbnQKqi3Zc1Uubpzp6WyTXaDoxLxlxX7QXt8K7cRaAviDZ/I07svoO9RwZPqGyeeyh4k1pAYTik8jY58rMmDCNcp6jM4AWAF786k77GI/DBzACJ7kt1Qe8fGLlm7UyV/nSZhxiKs3TcfqBypPf+tQzvfvSfRdVvoMQQOw38ogqT',
-  }
-
 }

--- a/manifests/public_key.pp
+++ b/manifests/public_key.pp
@@ -1,12 +1,27 @@
-class bootstrap::public_key ( 
-  $admin_user = $bootstrap::params::admin_user,
-  $ec2_lock_passwd = $bootstrap::params::ec2_lock_passwd
+class bootstrap::public_key (
+  String           $admin_user      = $bootstrap::params::admin_user,
+  Boolean          $ec2_lock_passwd = $bootstrap::params::ec2_lock_passwd,
+  String           $ssh_key         = $bootstrap::params::admin_ssh_key,
+  Optional[String] $additional_key  = undef,
 ) inherits bootstrap::params {
+
   ssh_authorized_key { 'instructor':
     user => $admin_user,
     type => 'ssh-rsa',
-    key  => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCv+89n9QU8kPxhsoRAHt5CZMy4cyA7vQ8k60wZmyUHnmFtXH8Ipusj9QyV8GsL/F64ci3bS0eHlk5XlAFACsLy4Gai6CQ2NAjkZRT7qG5BtoGr4aGXhxFCUZ2hgo2j18uU6GKl2akRPsYMsRgNrRglidENLY4WUCzacgr/1Cw8eRN95Mo9b4tgSLTCyd/783CBdeM8qU9Go7xq0nVRGNgsFIqf1SY+9k5dpSbL0M5lvDzl35IC1tRIQE/ZbafJok8g1XmhwKokWpGBRk9/GneWz3jDvJRZPjYHzQs+gSHNkl2F6i55EIlQqbfm/7lvtB73Pd2vT+i1AIgrx90YB4Yd',
+    key  => $ssh_key,
   }
+
+  if $additional_key {
+    # Provide a backup login method, primarily for student masters in Architect.
+    # The public half of this key is on the Downloads page of the Courseware presentation
+    ssh_authorized_key { 'student@puppet.com':
+      ensure => present,
+      user   => $admin_user,
+      type   => 'ssh-rsa',
+      key    => $additional_key,
+    }
+  }
+
   if defined('$::ec2_metadata') {
     file {'/etc/cloud/cloud.cfg.d/99_puppetlabs.cfg':
       ensure         => file,
@@ -17,4 +32,5 @@ class bootstrap::public_key (
       }),
     }
   }
+
 }

--- a/manifests/role/training.pp
+++ b/manifests/role/training.pp
@@ -15,7 +15,7 @@ class bootstrap::role::training inherits bootstrap::params {
 
   class { 'bootstrap::public_key':
     ec2_lock_passwd => false,
-    additional_key  => $bootstrap::params::admin_ssh_key
+    additional_key  => $bootstrap::params::additional_key,
   }
 
   class { 'abalone':

--- a/manifests/role/training.pp
+++ b/manifests/role/training.pp
@@ -1,5 +1,6 @@
 class bootstrap::role::training inherits bootstrap::params {
   include bootstrap
+  include userprefs::defaults
   include bootstrap::profile::ruby
   include bootstrap::profile::rubygems
   include bootstrap::profile::cache_modules
@@ -7,14 +8,16 @@ class bootstrap::role::training inherits bootstrap::params {
   include bootstrap::profile::cache_docker
   include bootstrap::profile::pdf_stack
   include bootstrap::profile::network
-  include userprefs::defaults
   include bootstrap::profile::splash
   include bootstrap::profile::cache_wordpress
   include bootstrap::profile::cache_gems
-  class { 'bootstrap::public_key': 
+  include bootstrap::profile::disable_selinux
+
+  class { 'bootstrap::public_key':
     ec2_lock_passwd => false,
+    additional_key  => $bootstrap::params::admin_ssh_key
   }
-  include bootstrap::profile::disable_selinux 
+
   class { 'abalone':
     port     => '9091',
     watchdog => true,


### PR DESCRIPTION
This allows us to inject a second ssh key for students in Architect to
log in directly via SSH, in case they're having troubles with Abalone or
just prefer a native solution.

This is the second attempt at this....