### PR TITLE
(TRAINTECH-1409) Add domains for hiera course to ssh_config

### DIFF
--- a/manifests/profile/learning/ssh.pp
+++ b/manifests/profile/learning/ssh.pp
@@ -9,9 +9,9 @@ class bootstrap::profile::learning::ssh {
   augeas { "disable_key_checking":
     context => '/files/etc/ssh/ssh_config',
     changes =>
-      ["set Host[.='*.puppet.vm'] *.puppet.vm",
-       "set Host[.='*.puppet.vm']/StrictHostKeyChecking no",
-       "set Host[.='*.puppet.vm']/UserKnownHostsFile /dev/null"],
+      ["set Host[.='*.puppet.vm *.auroch.vm *.beauvine.vm'] '*.puppet.vm *.auroch.vm *.beauvine.vm'",
+       "set Host[.='*.puppet.vm *.auroch.vm *.beauvine.vm']/StrictHostKeyChecking no",
+       "set Host[.='*.puppet.vm *.auroch.vm *.beauvine.vm']/UserKnownHostsFile /dev/null"],
     require => Package['ruby-augeas'],
   }
 


### PR DESCRIPTION
The /etc/ssh_config file on the Learning VM contains a section that
bypasses host key checking for container nodes. Prior to this commit, it
only does this for hosts following the *.puppet.vm pattern. This commit
adds *.auroch.vm and *.beauvine.vm domains used in the Hiera quest to
this pattern.