### PR TITLE
(MAINT) Update puppet-forge-server version

### DIFF
--- a/manifests/profile/puppet_forge_server.pp
+++ b/manifests/profile/puppet_forge_server.pp
@@ -16,7 +16,7 @@ class bootstrap::profile::puppet_forge_server(
     owner    => 'puppet-forge-server',
     group    => 'puppet-forge-server',
     source   => 'https://github.com/unibet/puppet-forge-server.git',
-    revision => '1.9.0',
+    revision => '1.10.1',
     require  => User['puppet-forge-server'],
   }
   exec { '/usr/local/bin/bundle install':


### PR DESCRIPTION
Tested locally by manually installing this version. There was a compatibility issue with the previous version and Forge API v3. Resolved with the version specified here.