### PR TITLE
Pre-install rack-test v 7.0

### DIFF
--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -22,4 +22,8 @@ class bootstrap::profile::rubygems {
     ensure   => '2.0.5',
     provider => gem,
   }
+  package { 'rack-test':
+    ensure   => '7.0',
+    provider => gem,
+  }
 }

--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -23,7 +23,7 @@ class bootstrap::profile::rubygems {
     provider => gem,
   }
   package { 'rack-test':
-    ensure   => '7.0',
+    ensure   => '0.7.0',
     provider => gem,
   }
 }

--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -23,7 +23,11 @@ class bootstrap::profile::rubygems {
     provider => gem,
   }
   package { 'rack-test':
-    ensure   => '0.6.4',
+    ensure   => '0.6.3',
+    provider => gem,
+  }
+  package { 'rack':
+    ensure   => '1.6.4',
     provider => gem,
   }
 }

--- a/manifests/profile/rubygems.pp
+++ b/manifests/profile/rubygems.pp
@@ -23,7 +23,7 @@ class bootstrap::profile::rubygems {
     provider => gem,
   }
   package { 'rack-test':
-    ensure   => '0.7.0',
+    ensure   => '0.6.4',
     provider => gem,
   }
 }


### PR DESCRIPTION
Versions of rack-test >= 7.1 require ruby >= 2.2.2. Rack-test is an implicit requirement of puppet-forge-server via sinatra-contrib. The dependency is open-ended, meaning bundler attempts to install the latest version of rack-test and fails because the ruby version doesn't meet requirements. Pre-installing this will resolve that issue.