### PR TITLE
(MAINT) Run ssh-agent in .bashrc.learningvm

### DIFF
--- a/files/learning/bashrc.learningvm
+++ b/files/learning/bashrc.learningvm
@@ -1,4 +1,5 @@
 export PROMPT_COMMAND='history -a; history -r'
 export PS1="\[\033[32m\][\w]\[\033[0m\]\n\[\033[1;31m\]\u@\h\[\033[1;31m\]: # \[\033[0m\]"
 [[ $- != *i* ]] && return
+eval `ssh-agent` > /dev/null 2>&1
 [[ -z "$TMUX" ]] && exec tmux && exec tmux attach


### PR DESCRIPTION
This prevents an ugly but unimpactful error message that pops up when running Bolt from the Learning VM.