### PR TITLE
(MAINT) Use postgresql module v 4.9.0

### DIFF
--- a/manifests/profile/learning/local_modules.pp
+++ b/manifests/profile/learning/local_modules.pp
@@ -13,7 +13,7 @@ class bootstrap::profile::learning::local_modules (
     "https://forge.puppet.com/v3/files/dwerder-graphite-5.16.1.tar.gz",
     "https://forge.puppet.com/v3/files/puppetlabs-apache-1.11.0.tar.gz",
     "https://forge.puppet.com/v3/files/puppetlabs-concat-2.2.0.tar.gz",
-    "https://forge.puppet.com/v3/files/puppetlabs-postgresql-4.8.0.tar.gz",
+    "https://forge.puppet.com/v3/files/puppetlabs-postgresql-4.9.0.tar.gz",
     "https://forge.puppet.com/v3/files/puppetlabs-apt-2.4.0.tar.gz",
   ]
 


### PR DESCRIPTION
There is a duplicate default clause in a conditional in v4.8.0 that seems to cause problems as of 2017.3.2