### PR TITLE
(LEARNVM-622) Add Gitea server to Learning VM

### DIFF
--- a/manifests/profile/gitea.pp
+++ b/manifests/profile/gitea.pp
@@ -1,0 +1,58 @@
+# This assumes that the gitea rpm and dependencies have been cached by the
+# pltraining-bootstrap module.
+class bootstrap::profile::gitea {
+
+  $gitea_address = $ipaddress
+
+  package { 'gitea':
+    ensure   => present,
+    name     => 'gitea',
+    source   => '/usr/src/rpm_cache/gitea.rpm',
+    provider => 'rpm',
+    require  => Exec['cache gitea rpm'],
+  }
+
+  ini_setting { "database user":
+    ensure  => present,
+    path    => '/home/git/go/bin/custom/conf/app.ini',
+    section => 'database',
+    setting => 'user',
+    value   => 'root',
+    require => Package['gitea'],
+    notify  => Service['gitea'],
+  }
+
+  ini_setting { "ssh domain":
+    ensure  => present,
+    path    => '/home/git/go/bin/custom/conf/app.ini',
+    section => 'server',
+    setting => 'SSH_DOMAIN',
+    value => $gitea_address,
+    require => Package['gitea'],
+    notify  => Service['gitea'],
+  }
+
+  ini_setting { "domain":
+    ensure  => present,
+    path    => '/home/git/go/bin/custom/conf/app.ini',
+    section => 'server',
+    setting => 'DOMAIN',
+    value => $gitea_address,
+    require => Package['gitea'],
+    notify  => Service['gitea'],
+  }
+  ini_setting { "root url":
+    ensure  => present,
+    path    => '/home/git/go/bin/custom/conf/app.ini',
+    section => 'server',
+    setting => 'ROOT_URL',
+    value => "http://${gitea_address}:3000/",
+    require => Package['gitea'],
+    notify  => Service['gitea'],
+  }
+
+  service { 'gitea':
+    ensure  => 'running',
+    enable  => true,
+  }
+}

--- a/manifests/role/learning.pp
+++ b/manifests/role/learning.pp
@@ -6,6 +6,8 @@ class bootstrap::role::learning {
   include bootstrap::profile::pe_tweaks
   include bootstrap::profile::abalone
   include bootstrap::profile::puppet_forge_server
+  include bootstrap::profile::cache_gitea
+  include bootstrap::profile::gitea
   include bootstrap::profile::learning::quest_guide
   include bootstrap::profile::learning::pe_tuning
   include bootstrap::profile::learning::install


### PR DESCRIPTION
Add a bootstrap::profile::gitea profile class and add this to
the learning role. The Gitea manifest is borrowed with slight
modification from the pltraining-classroom repository. Gitea is
necessary for the Control Repository quest on the Learning VM.