### PR TITLE
Add S3 cached pdftk package

### DIFF
--- a/templates/custom_packages.erb
+++ b/templates/custom_packages.erb
@@ -1,5 +1,6 @@
 <% if @build == 'master' -%>
 https://s3-us-west-2.amazonaws.com/education-packages/gitea-1.1.3-0.x86_64.rpm
+https://s3-us-west-2.amazonaws.com/education-packages/pdftk-2.02-1.el7.x86_64.rpm
 <% end -%>
 https://s3-us-west-2.amazonaws.com/education-packages/google-droid-sans-mono-1.0-1.x86_64.rpm
 https://puppet-pdk.s3.amazonaws.com/pdk/1.0.1.0/repos/el/7/PC1/x86_64/pdk-1.0.1.0-1.el7.x86_64.rpm


### PR DESCRIPTION
COPR went down today which left Gabe's class dead in the water. I believe S3 will be more reliable, especially on EC2 hosted instances. This is a package built by [LinuxGlobal](https://www.linuxglobal.com/pdftk-works-on-centos-7/) and tested to work without external dependencies.

TRAINTECH-1520 #resolved #time 1h