### PR TITLE
Use fork of puppet-forge-server with fixed rack-test dependency

### DIFF
--- a/manifests/profile/puppet_forge_server.pp
+++ b/manifests/profile/puppet_forge_server.pp
@@ -15,7 +15,7 @@ class bootstrap::profile::puppet_forge_server(
     provider => git,
     owner    => 'puppet-forge-server',
     group    => 'puppet-forge-server',
-    source   => 'https://github.com/unibet/puppet-forge-server.git',
+    source   => 'https://github.com/kjhenner/puppet-forge-server.git',
     revision => '1.10.1',
     require  => User['puppet-forge-server'],
   }


### PR DESCRIPTION
There is an open dependency specified in the puppet-forge-server gem that causes an installation problem with ruby < 2.2.2. I have corrected this issue in a fork of the repository. Use this fork pending a PR to the upstream repository.