### PR TITLE
Update cached modules

### DIFF
--- a/files/learning/defaults.yaml
+++ b/files/learning/defaults.yaml
@@ -23,4 +23,5 @@ puppet_enterprise::profile::orchestrator::pcp_timeout: 10
 puppet_enterprise::profile::orchestrator::java_args:
   Xmx: '64m'
   Xms: '64m'
-
+puppet_enterprise::master::code_manager::forge_settings:
+  baseurl: 'http://localhost:8085'

--- a/manifests/profile/learning/local_modules.pp
+++ b/manifests/profile/learning/local_modules.pp
@@ -5,14 +5,8 @@ class bootstrap::profile::learning::local_modules (
   include wget
   
   $learning_modules = [
-    "https://forge.puppet.com/v3/files/puppet-staging-2.2.0.tar.gz",
-    "https://forge.puppet.com/v3/files/puppetlabs-stdlib-4.7.0.tar.gz",
-    "https://forge.puppet.com/v3/files/puppetlabs-stdlib-4.15.0.tar.gz",
-    "https://forge.puppet.com/v3/files/puppetlabs-mysql-3.10.0.tar.gz",
-    "https://forge.puppet.com/v3/files/puppetlabs-ntp-6.0.0.tar.gz",
-    "https://forge.puppet.com/v3/files/dwerder-graphite-5.16.1.tar.gz",
-    "https://forge.puppet.com/v3/files/puppetlabs-apache-1.11.0.tar.gz",
-    "https://forge.puppet.com/v3/files/puppetlabs-concat-2.2.0.tar.gz",
+    "https://forge.puppet.com/v3/files/puppetlabs-stdlib-4.20.0.tar.gz",
+    "https://forge.puppet.com/v3/files/puppetlabs-concat-2.2.1.tar.gz",
     "https://forge.puppet.com/v3/files/puppetlabs-postgresql-4.9.0.tar.gz",
     "https://forge.puppet.com/v3/files/puppetlabs-apt-2.4.0.tar.gz",
   ]


### PR DESCRIPTION
Remove unused cached modules and add correct versions. Update defaults.yaml to set forge baseurl to local forge server.