### PR TITLE
This should persist the http redirect after install

### DIFF
--- a/files/hieradata/common.yaml
+++ b/files/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+puppet_enterprise::profile::console::proxy::http_redirect::enable_http_redirect: false

--- a/manifests/profile/pe_master.pp
+++ b/manifests/profile/pe_master.pp
@@ -44,8 +44,8 @@ class bootstrap::profile::pe_master (
   }
   file { '/etc/puppetlabs/code/environments/production/hieradata/common.yaml':
     ensure  => file,
-    owner   => 'root',
-    group   => 'root',
+    owner   => 'pe-puppet',
+    group   => 'pe-puppet',
     mode    => '0644',
     content => 'puppet:///modules/bootstrap/hieradata/common.yaml',
     notify  => Exec['install pe'],

--- a/manifests/profile/pe_master.pp
+++ b/manifests/profile/pe_master.pp
@@ -36,6 +36,21 @@ class bootstrap::profile::pe_master (
     notify  => Exec['install pe'],
   }
 
+  # Ensure that the redirect setting persists post install
+  # This should be replaced by filesync as soon as the classroom is classified.
+  dirtree { '/etc/puppetlabs/code/environments/production/hieradata/':
+    ensure  => present,
+    parents => true,
+  }
+  file { '/etc/puppetlabs/code/environments/production/hieradata/common.yaml':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => 'puppet:///modules/bootstrap/hieradata/common.yaml',
+    notify  => Exec['install pe'],
+  }
+
   exec { 'install pe':
     command     => "${destination}/puppet-enterprise-installer -D -c /opt/pltraining/etc/pe.conf",
     refreshonly => true,


### PR DESCRIPTION
I am pretty sure that what's happening here is that the installer
configures PE with the HTTP redirect disabled. But then it doesn't
persist the setting, so it gets turned back on (the default) as soon as
the first Puppet run happens.

This should correct that, though this file will be wiped out as soon as
the first Puppet code deploy happens. By then, we'll have reconfigured
and it won't matter though.

TRAINTECH-1564 #resolved #time 30m