### PR TITLE
Eliminate dependency cycle

### DIFF
--- a/manifests/profile/cache_modules.pp
+++ b/manifests/profile/cache_modules.pp
@@ -11,7 +11,7 @@ class bootstrap::profile::cache_modules {
     mode  => '0644',
   }
 
-  file { [$stagedir, $codedir]:
+  file { $stagedir: # $codedir is managed prior to the PE install now
     ensure => directory,
   }
 

--- a/manifests/profile/pe_master.pp
+++ b/manifests/profile/pe_master.pp
@@ -7,6 +7,7 @@ class bootstrap::profile::pe_master (
     fail("\n\nPE version ${pe_version} has been released for classroom usage. Please discard this VM and build a new one.\n\n")
   }
 
+  $hieradata            = "${bootstrap::params::codedir}/environments/production/hieradata"
   $destination          = "/tmp/puppet-enterprise-${pe_version}-el-7-x86_64"
   if $pre_release {
     $installer_filename = "puppet-enterprise-${pe_version}-el-7-x86_64.tar"
@@ -38,11 +39,13 @@ class bootstrap::profile::pe_master (
 
   # Ensure that the redirect setting persists post install
   # This should be replaced by filesync as soon as the classroom is classified.
-  dirtree { '/etc/puppetlabs/code/environments/production/hieradata/':
-    ensure  => present,
-    parents => true,
+  file { dirtree($hieradata, '/etc/puppetlabs'):
+    ensure => directory,
+    owner => 'pe-puppet',
+    group => 'pe-puppet',
+    mode  => '0644',
   }
-  file { '/etc/puppetlabs/code/environments/production/hieradata/common.yaml':
+  file { "${hieradata}/common.yaml":
     ensure  => file,
     owner   => 'pe-puppet',
     group   => 'pe-puppet',


### PR DESCRIPTION
Since $codedir was being managed another place, the prior commit
generated an implicit depencency.

TRAINTECH-1564 #time 30m