### PR TITLE
Manage codebase parts all in one place.

### DIFF
--- a/manifests/profile/cache_modules.pp
+++ b/manifests/profile/cache_modules.pp
@@ -2,8 +2,9 @@ class bootstrap::profile::cache_modules {
   require bootstrap::profile::pe_master
   include bootstrap::params
 
-  $stagedir = $bootstrap::params::stagedir
-  $codedir  = $bootstrap::params::codedir
+  $stagedir  = $bootstrap::params::stagedir
+  $codedir   = $bootstrap::params::codedir
+  $hieradata = "${stagedir}/environments/production/hieradata"
 
   File {
     owner => 'pe-puppet',
@@ -11,7 +12,7 @@ class bootstrap::profile::cache_modules {
     mode  => '0644',
   }
 
-  file { $stagedir: # $codedir is managed prior to the PE install now
+  file { [$stagedir, $codedir]:
     ensure => directory,
   }
 
@@ -26,6 +27,17 @@ class bootstrap::profile::cache_modules {
     path        => '/bin:/usr/bin:/opt/puppetlabs/bin',
     cwd         => $stagedir,
     refreshonly => true,
+  }
+
+  # Ensure that the redirect setting persists post install
+  # This will be replaced by filesync as soon as the classroom is classified.
+  file { dirtree($hieradata, $stagedir):
+    ensure => directory,
+  }
+  file { "${hieradata}/common.yaml":
+    ensure  => file,
+    content => 'puppet:///modules/bootstrap/hieradata/common.yaml',
+    before  => File["${codedir}/modules"],
   }
 
   file { "${codedir}/modules":

--- a/manifests/profile/pe_master.pp
+++ b/manifests/profile/pe_master.pp
@@ -7,7 +7,6 @@ class bootstrap::profile::pe_master (
     fail("\n\nPE version ${pe_version} has been released for classroom usage. Please discard this VM and build a new one.\n\n")
   }
 
-  $hieradata            = "${bootstrap::params::codedir}/environments/production/hieradata"
   $destination          = "/tmp/puppet-enterprise-${pe_version}-el-7-x86_64"
   if $pre_release {
     $installer_filename = "puppet-enterprise-${pe_version}-el-7-x86_64.tar"
@@ -34,26 +33,6 @@ class bootstrap::profile::pe_master (
     group   => 'root',
     mode    => '0644',
     content => template('bootstrap/pe.conf.erb'),
-    notify  => Exec['install pe'],
-  }
-
-  # Ensure that the redirect setting persists post install
-  # This should be replaced by filesync as soon as the classroom is classified.
-  user { 'pe-puppet':
-    ensure => present,
-  }
-  file { dirtree($hieradata, '/etc/puppetlabs'):
-    ensure => directory,
-    owner => 'pe-puppet',
-    group => 'pe-puppet',
-    mode  => '0644',
-  }
-  file { "${hieradata}/common.yaml":
-    ensure  => file,
-    owner   => 'pe-puppet',
-    group   => 'pe-puppet',
-    mode    => '0644',
-    content => 'puppet:///modules/bootstrap/hieradata/common.yaml',
     notify  => Exec['install pe'],
   }
 


### PR DESCRIPTION
This doesn't drop the `common.yaml` before install, but I realized that
it shouldn't matter since the install is running off the `pe.conf`
template. This will exist prior to the first PE agent run, and then when
the agent is classified and code deployment happens, it will all be
replaced anyway. (There's a small race condition in that, so there might
still be a Puppet run that flaps this setting, but that should go away
once we get the hiera configs all updated to match current best
practices.)

TRAINTECH-1564 #time 2h