### PR TITLE
Hard-coded passwords is a bad practice

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+bash_pwd: $1$hgIZHl1r$tEqMTzoXz.NBwtW3kFv33/

--- a/manifests/role/learning.pp
+++ b/manifests/role/learning.pp
@@ -28,7 +28,7 @@ class bootstrap::role::learning {
     install_bundler => true,
   }
   class { 'userprefs::bash':
-    password => '$1$hgIZHl1r$tEqMTzoXz.NBwtW3kFv33/',
+    password => hiera('bash_pwd'),
     replace  => true,
   }
   class {'userprefs::vim':


### PR DESCRIPTION
> hard-coded passwords is a bad practice

Greetings,

I am a security researcher, who is looking for security smells in Puppet scripts.
I noticed instances of hard-coded passwords, which are against the best practices
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I suggest use of hiera to mitigate this smell. Feedback is welcome.
