### PR TITLE
Moving SpecInfra changes to boostrap

### DIFF
--- a/files/Puppetfile
+++ b/files/Puppetfile
@@ -1,5 +1,5 @@
 mod 'binford2k/abalone',              '0.0.9'
-mod 'pltraining/classroom',           '2.0.3'
+mod 'pltraining/classroom',           '2.0.2'
 mod 'pltraining/classroom_legacy',    '1.8.4'  ## for legacy classroom support
 mod 'pltraining/dirtree',             '0.3.0'
 mod 'pltraining/dockeragent',         '0.0.15'

--- a/manifests/profile/classroom.pp
+++ b/manifests/profile/classroom.pp
@@ -27,10 +27,17 @@ class bootstrap::profile::classroom (
     source  => "puppet:///modules/bootstrap/serverspec/${role}",
   }
 
+  # Required specinfra version to not require ruby >= 2.2.6
+  package { 'specinfra':
+    ensure   => '2.74.0',
+    provider => gem,
+  }
+
   # used for updating and managing the classroom
   package { 'puppet-classroom-manager':
     ensure   => installed,
     provider => gem,
+    require  => Package['specinfra'],
   }
 
   file { '/opt/pltraining/etc/pagerduty.key':


### PR DESCRIPTION
Prior to this commit the specinfra versino was pinned in
pltraining-classroom, the trouble is that this module is run first.  Due
ot order of operatings specinfra needs to be pinned here.  Reverting
pltraining-classroom back to 2.0.2 to avoid a duplicate declaration of
package[specinfra]