### PR TITLE
Module updates to support PE 2019.8.1

### DIFF
--- a/files/learning/defaults.yaml
+++ b/files/learning/defaults.yaml
@@ -19,9 +19,5 @@ puppet_enterprise::master::puppetserver::jruby_max_active_instances: 1
 puppet_enterprise::profile::console::delayed_job_workers: 1
 #shared_buffers takes affect during install but is not managed after
 puppet_enterprise::profile::database::shared_buffers: '4MB' 
-puppet_enterprise::profile::orchestrator::pcp_timeout: 10 
-puppet_enterprise::profile::orchestrator::java_args:
-  Xmx: '64m'
-  Xms: '64m'
 puppet_enterprise::master::code_manager::forge_settings:
   baseurl: 'http://localhost:8085'

--- a/manifests/profile/learning/quest_tool.pp
+++ b/manifests/profile/learning/quest_tool.pp
@@ -24,6 +24,15 @@ class bootstrap::profile::learning::quest_tool (
     source => 'puppet:///modules/bootstrap/learning/bashrc.learningvm',
   }
 
+  # Install a specific version of minitest before the quest gem. This version
+  # does not force a specific version of Ruby as a dependency so it will not
+  # break the build if a later version is installed.
+  package { 'minitest':
+    ensure   => '5.11.1',
+    provider => gem,
+    before   => Package['quest'],
+  }
+
   package { 'quest':
     provider => gem,
   }

--- a/manifests/role/learning.pp
+++ b/manifests/role/learning.pp
@@ -8,7 +8,10 @@ class bootstrap::role::learning {
   include bootstrap::profile::puppet_forge_server
   include bootstrap::profile::cache_gitea
   include bootstrap::profile::gitea
-  include bootstrap::profile::learning::quest_guide
+  # include bootstrap::profile::learning::quest_guide
+  class { 'bootstrap::profile::learning::quest_guide':
+    git_branch => 'marshall-update',
+  }
   include bootstrap::profile::learning::pe_tuning
   include bootstrap::profile::learning::disable_bolt_analytics
   include bootstrap::profile::learning::install

--- a/manifests/role/learning.pp
+++ b/manifests/role/learning.pp
@@ -8,10 +8,7 @@ class bootstrap::role::learning {
   include bootstrap::profile::puppet_forge_server
   include bootstrap::profile::cache_gitea
   include bootstrap::profile::gitea
-  # include bootstrap::profile::learning::quest_guide
-  class { 'bootstrap::profile::learning::quest_guide':
-    git_branch => 'marshall-update',
-  }
+  include bootstrap::profile::learning::quest_guide
   include bootstrap::profile::learning::pe_tuning
   include bootstrap::profile::learning::disable_bolt_analytics
   include bootstrap::profile::learning::install

--- a/templates/custom_packages.erb
+++ b/templates/custom_packages.erb
@@ -6,5 +6,5 @@ https://s3-us-west-2.amazonaws.com/education-packages/google-droid-sans-mono-1.0
 https://puppet-pdk.s3.amazonaws.com/pdk/1.0.1.0/repos/el/7/PC1/x86_64/pdk-1.0.1.0-1.el7.x86_64.rpm
 <% end -%>
 <% if @build == 'learning' -%>
-https://yum.puppetlabs.com/puppet/el/7/x86_64/puppet-bolt-1.14.0-1.el7.x86_64.rpm
+http://yum.puppet.com/puppet-enterprise-tools/el/7/x86_64/puppet-bolt-2.22.0-1.el7.x86_64.rpm
 <% end -%>


### PR DESCRIPTION
- Pinned the minitest gem to get the quest tool installation working correctly
- Removed the memory constraints on the PE Orchestrator so it will work in the LVM
- Cache the latest version of the bolt RPM now that Bolt has been updated in the quest guide